### PR TITLE
[INFRA-1554] Log more debug info to help diagnose.

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -15,6 +15,9 @@ ssh_hosts=${SSH_HOSTS:-"git@github.com"}
 if [ "$ssh_key" != "" ]; then
 	echo "-----> Running SSH private key setup"
 
+	echo "[DEBUG] ssh_hosts: '${ssh_hosts}'" | indent
+	echo "[DEBUG] ssh_key start/end: '${ssh_key::6}..${ssh_key: -6}'" | indent
+
 	# The .ssh needs to be located in the home directory which is different to the
 	# home directory of the built machine. The symlink resolves the issue.
 	mkdir "$1/.ssh"
@@ -26,7 +29,7 @@ if [ "$ssh_key" != "" ]; then
 	ssh-add "$HOME/.ssh/id_rsa"
 	IFS=',' read -ra HOST <<< "$ssh_hosts"
 	for i in "${HOST[@]}"; do
-		ssh -oStrictHostKeyChecking=no -T $i 2>&1 | indent
+		ssh -oStrictHostKeyChecking=no -T $i -vvv 2>&1 | indent
 	done
 
 	exit 0


### PR DESCRIPTION
[INFRA-1554](https://cambly.atlassian.net/browse/INFRA-1554): Backend deploys failing (2024-07-09).

- Print ssh hosts and minimal start/end of ssh key.
- Use `-vvv` with `ssh`.

[INFRA-1554]: https://cambly.atlassian.net/browse/INFRA-1554?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ