### PR TITLE
[INFRA-1554] Clean up debug info and set bash failure flags.

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -o errexit -o nounset -o pipefail
 
 function indent() {
 	c='s/^/       /'
@@ -15,9 +16,6 @@ ssh_hosts=${SSH_HOSTS:-"git@github.com"}
 if [ "$ssh_key" != "" ]; then
 	echo "-----> Running SSH private key setup"
 
-	echo "[DEBUG] ssh_hosts: '${ssh_hosts}'" | indent
-	echo "[DEBUG] ssh_key start/end: '${ssh_key::6}..${ssh_key: -6}'" | indent
-
 	# The .ssh needs to be located in the home directory which is different to the
 	# home directory of the built machine. The symlink resolves the issue.
 	mkdir "$1/.ssh"
@@ -29,7 +27,7 @@ if [ "$ssh_key" != "" ]; then
 	ssh-add "$HOME/.ssh/id_rsa"
 	IFS=',' read -ra HOST <<< "$ssh_hosts"
 	for i in "${HOST[@]}"; do
-		ssh -oStrictHostKeyChecking=no -T $i -vvv 2>&1 | indent
+		ssh -oStrictHostKeyChecking=no -T $i 2>&1 | indent
 	done
 
 	exit 0


### PR DESCRIPTION
[INFRA-1554](https://cambly.atlassian.net/browse/INFRA-1554): Backend deploys failing (2024-07-09).

- Clean up https://github.com/Cambly/ssh-private-key-buildpack/pull/1.
- Enable bash flags that terminate scripts on first failure, as [recommended by Heroku support](https://help.heroku.com/1411285).

[INFRA-1554]: https://cambly.atlassian.net/browse/INFRA-1554?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ